### PR TITLE
ThreadGroup ramp packing option

### DIFF
--- a/step-controller/step-controller-server-webapp/src/main/resources/webapp/partials/artefacts/threadGroup.html
+++ b/step-controller/step-controller-server-webapp/src/main/resources/webapp/partials/artefacts/threadGroup.html
@@ -9,6 +9,7 @@
 				<dynamic-textfield label="'Number of threads'" tooltip="'Specifies the number of threads to be started.'" on-save="save()" dynamic-value="artefact.users" />
 				<dynamic-textfield label="'Pacing (ms)'" tooltip="'Specifies the amount of time between each iteration.'" on-save="save()" dynamic-value="artefact.pacing" />
 				<dynamic-textfield label="'Ramp-up (ms)'" tooltip="'Specifies the amount of time that should be taken to start all the threads. If left empty the ramp-up duration will be equal to the pacing.'" on-save="save()" dynamic-value="artefact.rampup" />
+				<dynamic-textfield label="'Pack'" tooltip="'Defines number of threads started together during rampup'" on-save="save()" dynamic-value="artefact.pack" />
 				<dynamic-textfield label="'Start offset (ms)'" tooltip="'Specifies the duration to wait before the ramp-up starts.'" on-save="save()" dynamic-value="artefact.startOffset" />
 			</div>
 		</div>

--- a/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/ThreadGroup.java
+++ b/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/ThreadGroup.java
@@ -30,6 +30,8 @@ public class ThreadGroup extends AbstractArtefact {
 	DynamicValue<Integer> iterations = new DynamicValue<Integer>(1);
 	
 	DynamicValue<Integer> rampup = new DynamicValue<Integer>(null);
+
+	DynamicValue<Integer> pack = new DynamicValue<Integer>(null);
 	
 	DynamicValue<Integer> pacing = new DynamicValue<Integer>(null);
 
@@ -73,6 +75,14 @@ public class ThreadGroup extends AbstractArtefact {
 
 	public void setPacing(DynamicValue<Integer> pacing) {
 		this.pacing = pacing;
+	}
+
+	public DynamicValue<Integer> getPack() {
+		return pack;
+	}
+
+	public void setPack(DynamicValue<Integer> pack) {
+		this.pack = pack;
 	}
 
 	public DynamicValue<Integer> getStartOffset() {

--- a/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/handlers/ThreadGroupHandler.java
+++ b/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/handlers/ThreadGroupHandler.java
@@ -52,12 +52,14 @@ public class ThreadGroupHandler extends ArtefactHandler<ThreadGroup, ReportNode>
 		final int numberOfIterations = testArtefact.getIterations().getOrDefault(Integer.class, 0);
 		final int pacing = testArtefact.getPacing().getOrDefault(Integer.class, 0);
 		final int rampup = testArtefact.getRampup().getOrDefault(Integer.class, pacing);
+		final int pack = testArtefact.getPack().getOrDefault(Integer.class, 1);
 		final int maxDuration = testArtefact.getMaxDuration().getOrDefault(Integer.class, 0);
 		final int startOffset = testArtefact.getStartOffset().getOrDefault(Integer.class, 0);
 
 		if (numberOfUsers <= 0) {
 			throw new RuntimeException("Invalid argument: The number of threads has to be higher than 0.");
 		}
+
 		if (maxDuration == 0 && numberOfIterations == 0) {
 			throw new RuntimeException(
 					"Invalid argument: Either specify the maximum duration or the number of iterations of the thread group.");
@@ -77,7 +79,7 @@ public class ThreadGroupHandler extends ArtefactHandler<ThreadGroup, ReportNode>
 			public Consumer<Integer> createWorkItemConsumer(WorkerController<Integer> groupController) {
 				return groupID -> {
 					try {
-						final long localStartOffset = startOffset + (long) ((1.0 * (groupID - 1)) / numberOfUsers * rampup);
+						final long localStartOffset = startOffset + (long) (1.0 * pack*Math.floor((groupID - 1)/pack) / numberOfUsers * rampup);
 
 						CancellableSleep.sleep(localStartOffset, context::isInterrupted, ThreadGroupHandler.class);
 
@@ -121,6 +123,8 @@ public class ThreadGroupHandler extends ArtefactHandler<ThreadGroup, ReportNode>
 		@JsonIgnore
 		int pacing;
 		@JsonIgnore
+		int pack;
+		@JsonIgnore
 		long groupStartTime;
 		@JsonIgnore
 		ThreadGroup threadGroup;
@@ -157,6 +161,14 @@ public class ThreadGroupHandler extends ArtefactHandler<ThreadGroup, ReportNode>
 
 		public void setPacing(int pacing) {
 			this.pacing = pacing;
+		}
+
+		public int getPack() {
+			return pack;
+		}
+
+		public void setPack(int pacing) {
+			this.pack = pack;
 		}
 
 		public long getGroupStartTime() {


### PR DESCRIPTION
Added option "Pack" requested b y Postfinance. In essence it will affect rampup in a way that users will be added not one by one but in predefined pack size. Default behavior would be pack 1.

Idea is to be easily do load test when we increase stepwise load every few minutes, so breakpoints would be more visible. Alternative approach could be to define multiple ThreadGroups but we consider it suboptimal and very timeconsuming for the tests that are planned.