### PR TITLE
Systemprop exec params

### DIFF
--- a/.run/StepRunnerWithPlansAnnotationTest.run.xml
+++ b/.run/StepRunnerWithPlansAnnotationTest.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="StepRunnerWithPlansAnnotationTest" type="JUnit" factoryName="JUnit" nameIsGenerated="true">
+    <module name="step-junit" />
+    <selectedOptions>
+      <option name="environmentVariables" visible="false" />
+    </selectedOptions>
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="step.client.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <option name="PACKAGE_NAME" value="step.client" />
+    <option name="MAIN_CLASS_NAME" value="step.client.StepRunnerWithPlansAnnotationTest" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="class" />
+    <option name="VM_PARAMETERS" value="-ea -DexecParams=&quot;{ \&quot;PARAM_EXEC\&quot; : \&quot;value2\&quot;}&quot;" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/step-core/src/main/java/step/core/artefacts/reports/ReportNode.java
+++ b/step-core/src/main/java/step/core/artefacts/reports/ReportNode.java
@@ -215,8 +215,8 @@ public class ReportNode extends AbstractIdentifiableObject {
 		return false;
 	}
 
-//	@Override
-//	public String toString() {
-//		return "ReportNode [name=" + name + ", id=" + getId() + "]";
-//	}
+	@Override
+	public String toString() {
+		return "ReportNode=[name=" + name + ", id=" + getId() + "]";
+	}
 }

--- a/step-junit/src/main/java/step/junit/runner/Step.java
+++ b/step-junit/src/main/java/step/junit/runner/Step.java
@@ -100,6 +100,9 @@ public class Step extends ParentRunner<StepClassParserResult> {
 				} else if (resultStatus != ReportNodeStatus.PASSED) {
 					notifyFailure(childNotifier, result, "The plan execution returned an unexpected status\" + result",
 							false);
+				}else {
+					// We actually also want to see results when tests complete successfully
+					result.printTree();
 				}
 			} else {
 				childNotifier.addFailure(initializingException);

--- a/step-junit/src/main/java/step/junit/runners/annotations/ExecutionParameters.java
+++ b/step-junit/src/main/java/step/junit/runners/annotations/ExecutionParameters.java
@@ -26,6 +26,8 @@ import java.lang.annotation.RetentionPolicy;
  * @author exense team
  */
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ExecutionParameters {	
+public @interface ExecutionParameters {
+	public static String EXEC_PARAMS_KEY = "execParams";
+
 	String[] value();
 }

--- a/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/reports/EchoReportNode.java
+++ b/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/reports/EchoReportNode.java
@@ -31,4 +31,9 @@ public class EchoReportNode extends ReportNode {
 	public void setEcho(String echo) {
 		this.echo = echo;
 	}
+
+	@Override
+	public String toString(){
+		return "EchoReportNode=[" + echo + "]";
+	}
 }

--- a/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/reports/EchoReportNode.java
+++ b/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/reports/EchoReportNode.java
@@ -34,6 +34,6 @@ public class EchoReportNode extends ReportNode {
 
 	@Override
 	public String toString(){
-		return "EchoReportNode=[" + echo + "]";
+		return "EchoReportNode=[echo=" + echo + "]";
 	}
 }

--- a/step-plans/step-plans-core/src/main/java/step/core/plans/runner/PlanRunnerResult.java
+++ b/step-plans/step-plans-core/src/main/java/step/core/plans/runner/PlanRunnerResult.java
@@ -173,7 +173,7 @@ public class PlanRunnerResult {
 						bWriter.write(" ");
 				}
 				ReportNode node = event.getNode();
-				bWriter.write(node.getName()+":"+node.getStatus()+":"+(node.getError()!=null?node.getError().getMsg():""));
+				bWriter.write(node.getName()+":"+node.getStatus()+":"+(node.getError()!=null?node.getError().getMsg():"" + node.toString()));
 				bWriter.write("\n");
 				
 				if(printAttachments) {


### PR DESCRIPTION
Made the necessary changes for the two highlighted spots from the attached image to work.

![image](https://user-images.githubusercontent.com/5418782/206275920-2eaf1efd-5334-4976-8d3f-6c5386c9d429.png)

I feel like the way the results are printed should be made configureable because it's very difficult to understand what's going on right now (even when there is a failure and the tree is printed). That way we may be able to achieve the same results without having to sign every NodeReport with a concrete toString() method.

What's your point of view on this?