### PR TITLE
SED-1242-Added maven dependency management

### DIFF
--- a/step-parent/pom.xml
+++ b/step-parent/pom.xml
@@ -85,6 +85,16 @@
 		</repository>
 	</repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>2.0.1.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Added javax.validation in maven dependency management, so it can be easily imported (without a version) anywhere we define models and need to specify mandatory fields