### PR TITLE
SED-2506-function-importer-does-not-correctly-import-schemas-with-non-ascii-characters

### DIFF
--- a/step-functions/step-functions-package/src/main/java/step/functions/packages/handlers/AbstractFunctionPackageHandler.java
+++ b/step-functions/step-functions-package/src/main/java/step/functions/packages/handlers/AbstractFunctionPackageHandler.java
@@ -1,15 +1,7 @@
 package step.functions.packages.handlers;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.util.List;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import ch.exense.commons.processes.ManagedProcess;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import step.attachments.FileResolver;
@@ -17,7 +9,10 @@ import step.core.objectenricher.ObjectEnricher;
 import step.functions.Function;
 import step.functions.packages.FunctionPackage;
 import step.functions.packages.FunctionPackageHandler;
-import step.functions.packages.FunctionPackageManager;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 public abstract class AbstractFunctionPackageHandler extends FunctionPackageUtils implements FunctionPackageHandler {
 
@@ -61,7 +56,7 @@ public abstract class AbstractFunctionPackageHandler extends FunctionPackageUtil
 
 		FunctionList list;
 		try (BufferedReader inputStream = new BufferedReader(
-				new InputStreamReader(discovererDeamon.getProcessInputStream()))) {
+				new InputStreamReader(discovererDeamon.getProcessInputStream(), StandardCharsets.UTF_8))) {
 			String res;
 			do {
 				res = inputStream.readLine();
@@ -75,9 +70,7 @@ public abstract class AbstractFunctionPackageHandler extends FunctionPackageUtil
 
 		if (list.exception == null) {
 			List<Function> functions = list.getFunctions();
-			functions.forEach(f -> {
-				configureFunction(f, functionPackage);
-			});
+			functions.forEach(f -> configureFunction(f, functionPackage));
 			return list.getFunctions();
 		} else {
 			throw new Exception(list.exception);

--- a/step-functions/step-functions-package/src/main/java/step/functions/packages/handlers/JavaFunctionPackageDaemon.java
+++ b/step-functions/step-functions-package/src/main/java/step/functions/packages/handlers/JavaFunctionPackageDaemon.java
@@ -1,9 +1,8 @@
 package step.functions.packages.handlers;
 
-import java.io.File;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -43,21 +42,20 @@ public class JavaFunctionPackageDaemon extends FunctionPackageUtils {
 				parameter = objectMapper.readValue(reader, DiscovererParameters.class);
 			}
 			FunctionList list = daemon.getFunctions(parameter);
-			
-			try (OutputStreamWriter writer = new OutputStreamWriter(System.out)) {
+			try (OutputStreamWriter writer = new OutputStreamWriter(System.out, StandardCharsets.UTF_8)) {
 				writer.write(READY_STRING+"\n");
 				writer.write(objectMapper.writeValueAsString(list));
 			}
 		} catch (Exception e) {
 			FunctionList list = new FunctionList();
 			list.exception = e.getMessage();
-			try (OutputStreamWriter writer = new OutputStreamWriter(System.out)) {
+			try (OutputStreamWriter writer = new OutputStreamWriter(System.out, StandardCharsets.UTF_8)) {
 				writer.write(READY_STRING);
 				writer.write(objectMapper.writeValueAsString(list));
 			}
 		}
 	}
-	
+
 	protected FunctionList getFunctions(DiscovererParameters parameters) {
 		FunctionList functions = new FunctionList();
 		try {

--- a/step-functions/step-functions-package/src/test/java/step/functions/packages/EmbeddedFunctionPackageImporterTest.java
+++ b/step-functions/step-functions-package/src/test/java/step/functions/packages/EmbeddedFunctionPackageImporterTest.java
@@ -54,6 +54,7 @@ public class EmbeddedFunctionPackageImporterTest {
 		// Assert that the function package contains the attributes defined in the meta file
 		assertEquals("value1", functionPackage.getAttribute("attribute1"));
 		assertEquals("value2", functionPackage.getAttribute("attribute2"));
+		assertEquals("Äöüßêï", functionPackage.getAttribute("attributeI18n"));
 		
 		List<ObjectId> functionIDs = functionPackage.getFunctions();
 		Assert.assertEquals(3, functionIDs.size());

--- a/step-functions/step-functions-package/src/test/resources/local/java-plugin-handler-test.jar.json
+++ b/step-functions/step-functions-package/src/test/resources/local/java-plugin-handler-test.jar.json
@@ -1,6 +1,7 @@
 {
 	"attributes": {
 		"attribute1": "@ref1",
-		"attribute2": "value2"
+		"attribute2": "value2",
+		"attributeI18n": "Äöüßêï"
 	}
 }


### PR DESCRIPTION
This is somewhat hard to reproduce, but it seems to fail on some systems where the default isn't UTF-8. So make sure to explicitly read/write everything as UTF-8.