### PR TITLE
SED-2730 setting the Check control to "NORUN" if the root keyword fails

### DIFF
--- a/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/handlers/CheckHandler.java
+++ b/step-plans/step-plans-base-artefacts/src/main/java/step/artefacts/handlers/CheckHandler.java
@@ -41,6 +41,8 @@ public class CheckHandler extends ArtefactHandler<Check, CheckReportNode> {
 				node.setStatus(ReportNodeStatus.FAILED);
 				node.addError("The expression '" + testArtefact.getExpression().getExpression() + "' returned false");
 			}
+		} else {
+			node.setStatus(ReportNodeStatus.NORUN);
 		}
 	}
 


### PR DESCRIPTION
@jeromecomte : tested here https://stepos-sed-2730.stepcloud-test.ch/#/root/executions/65a679dfedc01c547bc93f88/steps
