### PR TITLE
SED-3269 better SQL table name detection, on write only

### DIFF
--- a/step-plans/step-plans-base-artefacts/src/test/java/step/datapool/jdbc/SQLDataSetArtefactsTest.java
+++ b/step-plans/step-plans-base-artefacts/src/test/java/step/datapool/jdbc/SQLDataSetArtefactsTest.java
@@ -78,7 +78,7 @@ public class SQLDataSetArtefactsTest extends AbstractDataPoolTest {
 		conf.setDriverClass(new DynamicValue<>("com.mysql.cj.jdbc.Driver"));
 		conf.setUser(new DynamicValue<>(USER));
 		conf.setPassword(new DynamicValue<>(PASS));
-		conf.setForWrite(new DynamicValue<>(false));
+		conf.setForWrite(new DynamicValue<>(true));
 		conf.setWritePKey(new DynamicValue<>("Col1"));
 
 		return conf;

--- a/step-plans/step-plans-base-artefacts/src/test/java/step/datapool/jdbc/SQLTableDataSetTest.java
+++ b/step-plans/step-plans-base-artefacts/src/test/java/step/datapool/jdbc/SQLTableDataSetTest.java
@@ -68,7 +68,7 @@ public class SQLTableDataSetTest extends AbstractArtefactTest {
 			conf.setDriverClass(new DynamicValue<>("com.mysql.cj.jdbc.Driver"));
 			conf.setUser(new DynamicValue<>(USER));
 			conf.setPassword(new DynamicValue<>(PASS));
-			conf.setForWrite(new DynamicValue<>(false));
+			conf.setForWrite(new DynamicValue<>(true));
 			conf.setWritePKey(new DynamicValue<>("id"));
 			ds = DataPoolFactory.getDataPool("sql", conf, newExecutionContext());
 			ds.init();


### PR DESCRIPTION
As discussed, this PR uses a slightly "stronger" regex to determine the SQL table to write to, and most importantly only does so when a DataSet is actually marked as "for writing" (otherwise, it's not needed anyway).

I'm not sure how a meaningful unit test would look like though...