### PR TITLE
SED-3465 ensure correct commons-io version is bundled in distribution

### DIFF
--- a/step-plans/step-plans-base-artefacts/pom.xml
+++ b/step-plans/step-plans-base-artefacts/pom.xml
@@ -66,6 +66,17 @@
 			<groupId>ch.exense.step</groupId>
 			<artifactId>step-grid-server</artifactId>
 		</dependency>
+
+		<!-- ATTENTION: Apache POI declares a dependency to an old version of commons-io (2.11)
+		that even POI itself is not entirely functional with. Because this is the "outermost"
+		place where that dependency is defined, it would actually fix an OLD (incomplete, and
+		vulnerable) version as the preferred one. We therefore manually define the correct
+		preferred dependency here (the version to use is automatically correctly determined)
+		-->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>


### PR DESCRIPTION
Seems to have worked, here's the resulting distribution build: https://ftps-staging.exense.ch/step/2024.10.10-6707c2d67ed747704e9fb136/step-controller-2024.10.10-6707c2d67ed747704e9fb136.zip

