### PR TITLE
SED-3367 Add 'involved agents' to execution

### DIFF
--- a/step-plans/step-plans-core/src/main/java/step/core/execution/model/Execution.java
+++ b/step-plans/step-plans-core/src/main/java/step/core/execution/model/Execution.java
@@ -53,6 +53,7 @@ public class Execution extends AbstractOrganizableObject implements EnricheableO
 	private ExecutionParameters executionParameters;
 	private ExecutiontTaskParameters executiontTaskParameters;
 	private String resolvedPlanRootNodeId;
+	private String agentsInvolved;
 
 	public Execution() {
 		super();
@@ -228,6 +229,20 @@ public class Execution extends AbstractOrganizableObject implements EnricheableO
 
 	public void setResolvedPlanRootNodeId(String resolvedPlanRootNodeId) {
 		this.resolvedPlanRootNodeId = resolvedPlanRootNodeId;
+	}
+
+	/**
+	 * Returns a list of agents (i.e., their agent URLs) that were involved in the execution.
+	 * This is only populated after an execution has ended, and may not be available for all executions,
+	 * so null or empty values can be expected and should be treated as "unavailable/not applicable"
+	 * @return the list of involved agents (space-separated)
+	 */
+	public String getAgentsInvolved() {
+		return agentsInvolved;
+	}
+
+	public void setAgentsInvolved(String agentsInvolved) {
+		this.agentsInvolved = agentsInvolved;
 	}
 
 	@Override

--- a/step-plans/step-plans-core/src/main/java/step/engine/execution/ExecutionManager.java
+++ b/step-plans/step-plans-core/src/main/java/step/engine/execution/ExecutionManager.java
@@ -2,12 +2,17 @@ package step.engine.execution;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import step.core.artefacts.reports.ReportNode;
 import step.core.execution.ExecutionContext;
 import step.core.execution.model.Execution;
 import step.core.execution.model.ExecutionAccessor;
 import step.core.execution.model.ExecutionStatus;
 
+import java.lang.reflect.Method;
+import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ExecutionManager {
 
@@ -35,9 +40,36 @@ public class ExecutionManager {
         updateExecution(execution->{
             if (newStatus == ExecutionStatus.ENDED) {
                 execution.setEndTime(System.currentTimeMillis());
+                Stream<ReportNode> reportNodes = executionContext.getReportNodeAccessor().getReportNodesByExecutionID(executionContext.getExecutionId());
+                String agentsInvolved = getAgentsInvolvedAsJoinedString(reportNodes);
+                execution.setAgentsInvolved(agentsInvolved);
             }
             execution.setStatus(newStatus);
         });
+    }
+
+    private String getAgentsInvolvedAsJoinedString(Stream<ReportNode> reportNodes) {
+        return reportNodes
+                .map(this::getAgentUrlFromReportNode)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet())
+                .stream().sorted(String.CASE_INSENSITIVE_ORDER)
+                .collect(Collectors.joining(" "));
+    }
+
+    private String getAgentUrlFromReportNode(ReportNode reportNode) {
+        // we know that only CallFunctionReportNodes contain agent information, but we don't have access to the class definition here.
+        if (reportNode.getClass().getName().equals("step.artefacts.reports.CallFunctionReportNode")) {
+            try {
+                Method getter = reportNode.getClass().getMethod("getAgentUrl");
+                return (String) getter.invoke(reportNode);
+            } catch (Exception e) {
+                // should never happen
+                logger.error(e.getMessage(), e);
+                return null;
+            }
+        }
+        return null;
     }
 
     public void updateExecution(Consumer<Execution> consumer) {


### PR DESCRIPTION
This is conceptually pretty simple actually - after an execution has ended, just go through the execution report and gather all agent URLs.

This is a draft for now, as 1) it only is able to retrieve agent URLs from KW calls (but I think this actually is the only node type which explicitly provides that information), and 2) the code is slightly ugly because it needs to work by reflection as it doesn't have access to the actual class definitions (in terms of encapsulation: the module only knows about the supertype, but not the implementing subtypes). I did not find another solution that wouldn't be massively more complicated, but I'm open to suggestions (potentially a dedicated plugin just for that?)