### PR TITLE
SED-4193 use subfolder of resources.dir for streaming resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<step-grid.version>2025.8.22-68a884e5a5fd2f5679a576ad</step-grid.version>
 		<step-framework.version>2025.8.22-68a887b0a5fd2f5679a819d2</step-framework.version>
 		<!-- TODO: REMOVE temporary overrides (and usages) before merging to productive branch -->
-		<step-api-temp-override.version>2025.8.25-68ac3c6c0ad99e784e86744e</step-api-temp-override.version>
+		<step-api-temp-override.version>2025.8.25-68ac78150ad99e784ec15634</step-api-temp-override.version>
 
 		<!-- external, non-transitive, dependencies -->
 		<dep.groovy.version>3.0.23</dep.groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<step-grid.version>2025.8.22-68a884e5a5fd2f5679a576ad</step-grid.version>
 		<step-framework.version>2025.8.22-68a887b0a5fd2f5679a819d2</step-framework.version>
 		<!-- TODO: REMOVE temporary overrides (and usages) before merging to productive branch -->
-<!--		<step-api-temp-override.version>2025.8.21-68a72c6ba5fd2f56796ae745</step-api-temp-override.version>-->
+		<step-api-temp-override.version>2025.8.25-68ac3c6c0ad99e784e86744e</step-api-temp-override.version>
 
 		<!-- external, non-transitive, dependencies -->
 		<dep.groovy.version>3.0.23</dep.groovy.version>
@@ -118,13 +118,13 @@
 			<!-- We're temporarily forcing the step-api version here (which also sets the streaming version).
 			TODO: remove block before merging to productive branch -->
 <!--			 reenable when needed, otherwise delete-->
-<!--			<dependency>-->
-<!--				<groupId>ch.exense.step</groupId>-->
-<!--				<artifactId>step-api</artifactId>-->
-<!--				<version>${step-api-temp-override.version}</version>-->
-<!--				<type>pom</type>-->
-<!--				<scope>import</scope>-->
-<!--			</dependency>-->
+			<dependency>
+				<groupId>ch.exense.step</groupId>
+				<artifactId>step-api</artifactId>
+				<version>${step-api-temp-override.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 
 			<dependency>
 				<groupId>ch.exense.step</groupId>

--- a/step-controller/step-controller-base-plugins/src/main/java/step/plugins/streaming/StreamingResourcesControllerPlugin.java
+++ b/step-controller/step-controller-base-plugins/src/main/java/step/plugins/streaming/StreamingResourcesControllerPlugin.java
@@ -16,6 +16,7 @@ import step.core.plugins.AbstractControllerPlugin;
 import step.core.plugins.Plugin;
 import step.engine.plugins.AbstractExecutionEnginePlugin;
 import step.engine.plugins.ExecutionEnginePlugin;
+import step.resources.ResourceManagerControllerPlugin;
 import step.streaming.common.StreamingResourceUploadContexts;
 import step.streaming.server.*;
 import step.streaming.websocket.server.DefaultWebsocketServerEndpointSessionsHandler;
@@ -66,12 +67,8 @@ public class StreamingResourcesControllerPlugin extends AbstractControllerPlugin
 
         websocketBaseUrl = websocketBaseUri.toString();
 
-        // FIXME - temporary code - make configurable
-        File storageBaseDir = new File(System.getProperty("os.name").toLowerCase().contains("win") ? "C:/Temp/streaming-storage" : "/tmp/streaming-storage");
-        Path controllerData = Paths.get("/home/controller/data");
-        if (Files.exists(controllerData)) {
-            storageBaseDir = new File(controllerData.toString(), "streaming-storage");
-        }
+        File resourcesRootDir = new File(ResourceManagerControllerPlugin.getResourceDir(context.getConfiguration()));
+        File storageBaseDir = new File(resourcesRootDir, "streamedAttachment");
 
         FilesystemStreamingResourcesStorageBackend storage = new FilesystemStreamingResourcesStorageBackend(storageBaseDir);
         StreamingResourceCollectionCatalogBackend catalog = new StreamingResourceCollectionCatalogBackend(context);


### PR DESCRIPTION
As discussed, using subfolder of existing configured folder instead of configuring separately - basically trivial PR now