### PR TITLE
Fix CJS keyword lookup via .default interop in agent-fork.js

### DIFF
--- a/step-node/step-node-agent/api/controllers/agent-fork.js
+++ b/step-node/step-node-agent/api/controllers/agent-fork.js
@@ -100,8 +100,11 @@ process.on('message', async ({ type, projectPath, functionName, input, propertie
   }
 
   function searchKeyword(kwModules, keywordName) {
-    const kwModule = kwModules.find(m => m[keywordName]);
-    return kwModule ? {keywordFunction: kwModule[keywordName], keywordModule: kwModule} : undefined;
+    for (const m of kwModules) {
+      if (m[keywordName]) return { keywordFunction: m[keywordName], keywordModule: m };
+      if (m.default?.[keywordName]) return { keywordFunction: m.default[keywordName], keywordModule: m.default };
+    }
+    return undefined;
   }
 });
 

--- a/step-node/step-node-agent/test/keywords/keywords-bundled-cjs.js
+++ b/step-node/step-node-agent/test/keywords/keywords-bundled-cjs.js
@@ -1,0 +1,21 @@
+// Simulates bundler-compiled CJS (Bun, esbuild, webpack) where all exports
+// are wrapped in a single `module.exports` object.  Node's import() puts this
+// on `.default` instead of hoisting individual named exports.
+
+var keywords_exports = {};
+
+keywords_exports.BundledEcho = async (input, output, session, properties) => {
+  input['properties'] = properties
+  Object.entries(input).forEach(([k, v]) => output.add(k, v))
+}
+
+keywords_exports.onError = async (exception, input, output, session, properties) => {
+  output.builder.payload.payload.onErrorCalled = true
+  return input['rethrow_error']
+}
+
+keywords_exports.BundledErrorKW = async (input, output, session, properties) => {
+  throw new Error(input['ErrorMsg'])
+}
+
+module.exports = keywords_exports;

--- a/step-node/step-node-agent/test/runner.test.js
+++ b/step-node/step-node-agent/test/runner.test.js
@@ -271,6 +271,23 @@ describe('runner', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // Bundler-compiled CJS interop (issue #628)
+  // ---------------------------------------------------------------------------
+
+  describe('bundler-compiled CJS keywords (.default interop)', () => {
+    test('finds and executes a keyword from a module.exports wrapper', async () => {
+      const output = await runner.run('BundledEcho', { Param1: 'BundledVal' })
+      expect(output.payload.Param1).toBe('BundledVal')
+    })
+
+    test('onError hook works for bundler-compiled CJS keywords', async () => {
+      const output = await runner.run('BundledErrorKW', { ErrorMsg: 'bundled error', rethrow_error: true })
+      expect(output.error.msg).toBe('bundled error')
+      expect(output.payload.onErrorCalled).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // beforeKeyword and afterKeyword hooks
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #628.

- `searchKeyword` in `agent-fork.js` now checks `m.default?.[keywordName]` as a fallback when the keyword isn't found as a top-level named export
- When matching via `.default`, `keywordModule` resolves to `m.default` so that `onError`, `beforeKeyword`, and `afterKeyword` hooks are found on the correct object
- Adds test fixture (`keywords-bundled-cjs.js`) simulating bundler-compiled CJS and 2 new tests

## Context

After the SED-4581 `require()` → `import()` switch, bundler-compiled CJS modules (Bun, esbuild, webpack) that use `module.exports = __toCommonJS(...)` patterns fail with "Unable to find Keyword". Node's `import()` wraps `module.exports` into `.default` on the namespace object, and only simple `exports.X = fn` patterns get hoisted as named exports.

## Test plan

- [x] All 46 tests pass (`npm test` in step-node-agent)
- [x] New tests verify keyword execution and onError hook resolution through `.default` interop
- [ ] Manual test with a Bun-compiled CJS keyword package