### PR TITLE
SED-4920 Fragment path with white spaces causes undescriptive error upon AP upload

### DIFF
--- a/step-core/src/main/java/step/automation/packages/ClassLoaderResourceFilesystem.java
+++ b/step-core/src/main/java/step/automation/packages/ClassLoaderResourceFilesystem.java
@@ -28,6 +28,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -170,7 +172,7 @@ public class ClassLoaderResourceFilesystem {
         public JarResourcePath(URL url) throws MalformedURLException {
             String urlFile = url.getFile();
             int bangIndex = urlFile.indexOf('!');
-            pathInJar = urlFile.substring(bangIndex + 2);
+            pathInJar = URLDecoder.decode(urlFile.substring(bangIndex + 2), StandardCharsets.UTF_8);
             jarFile = new URL(urlFile.substring(0, bangIndex)).getFile();
         }
     }

--- a/step-core/src/main/java/step/automation/packages/ResourcePathMatchingResolver.java
+++ b/step-core/src/main/java/step/automation/packages/ResourcePathMatchingResolver.java
@@ -21,8 +21,11 @@ package step.automation.packages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.*;
-import java.util.*;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class ResourcePathMatchingResolver {
@@ -85,7 +88,7 @@ public class ResourcePathMatchingResolver {
                             file = file.substring(0, file.length() - 1);
                         }
                         int lastIndexOf = file.lastIndexOf(getPathSeparator());
-                        String lastPath = file.substring(lastIndexOf + 1);
+                        String lastPath = URLDecoder.decode(file.substring(lastIndexOf + 1), StandardCharsets.UTF_8);
                         if (pattern.matcher(lastPath).matches()) {
                             findPathMatchingResourcesRecursive(pathArray, nextLevel, url, result);
                         }


### PR DESCRIPTION
@david-stephan I propose the following fix, will still implement some unit tests to be sure